### PR TITLE
Parse available settings; add scenemode switch

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -12,4 +12,5 @@ disable=
   arguments-differ,
   too-many-arguments,
   too-many-locals,
-  too-many-instance-attributes
+  too-many-instance-attributes,
+  too-many-public-methods


### PR DESCRIPTION
Switching camera scene modes can help a great deal with optimal picture quality; particularly night modes are far better than just increasing exposure and turning up night gain.

The available scenes depend on device capability, and they are available through `/status.json?show_avail=1` which adds an `avail` dict with all possible settings and their options.

We can then present available scene modes and toggle them based only on what is available.