### PR TITLE
Added Enable/Disable motion detection function

### DIFF
--- a/pydroid_ipcam.py
+++ b/pydroid_ipcam.py
@@ -244,7 +244,14 @@ class PyDroidIPCam(object):
             _LOGGER.debug('%s is not a valid orientation', orientation)
             return False
         return self.change_setting('orientation', orientation)
+    
+    def set_motion_detect(self, activate=True):
+        """Enable/disable motion detection.
 
+        Return a coroutine.
+        """
+        return self.change_setting('motion_detect', activate)    
+    
     def set_zoom(self, zoom):
         """Set the zoom level.
 


### PR DESCRIPTION
I use this to prevent motion detection from triggering video recording when I switch between front and rear cameras. I thought it would be nice to have in the official version.