### PR TITLE
SSL support

### DIFF
--- a/pydroid_ipcam.py
+++ b/pydroid_ipcam.py
@@ -11,22 +11,26 @@ ALLOWED_ORIENTATIONS = [
     'landscape', 'upsidedown', 'portrait', 'upsidedown_portrait'
 ]
 
+DEFAULT_PORT = 8080
+DEFAULT_SSL = True
+
 
 class PyDroidIPCam:
     """The Android device running IP Webcam."""
 
-    def __init__(self, loop, websession, host, port, username=None,
-                 password=None, timeout=10):
+    def __init__(self, loop, websession, host, port=DEFAULT_PORT, username=None,
+                 password=None, timeout=10, ssl=DEFAULT_SSL):
         """Initialize the data oject."""
         self.loop = loop
         self.websession = websession
         self.status_data = None
         self.sensor_data = None
         self._host = host
-        self._port = port
+        self._port = port if port is not None else DEFAULT_PORT
         self._auth = None
         self._timeout = None
         self._available = True
+        self._ssl = ssl if ssl is not None else DEFAULT_SSL
 
         if username and password:
             self._auth = aiohttp.BasicAuth(username, password=password)
@@ -34,7 +38,8 @@ class PyDroidIPCam:
     @property
     def base_url(self):
         """Return the base url for endpoints."""
-        return "http://{}:{}".format(self._host, self._port)
+        protocol = "https" if self._ssl else "http"
+        return "{}://{}:{}".format(protocol, self._host, self._port)
 
     @property
     def mjpeg_url(self):

--- a/pydroid_ipcam.py
+++ b/pydroid_ipcam.py
@@ -39,17 +39,17 @@ class PyDroidIPCam:
     def base_url(self):
         """Return the base url for endpoints."""
         protocol = "https" if self._ssl else "http"
-        return "{}://{}:{}".format(protocol, self._host, self._port)
+        return f"{protocol}://{self._host}:{self._port}"
 
     @property
     def mjpeg_url(self):
         """Return mjpeg url."""
-        return "{}/video".format(self.base_url)
+        return f"{self.base_url}/video"
 
     @property
     def image_url(self):
         """Return snapshot image url."""
-        return "{}/shot.jpg".format(self.base_url)
+        return f"{self.base_url}/shot.jpg"
 
     @property
     def available(self):
@@ -58,7 +58,7 @@ class PyDroidIPCam:
 
     async def _request(self, path):
         """Make the actual request and return the parsed response."""
-        url = '{}{}'.format(self.base_url, path)
+        url = f'{self.base_url}{path}'
         data = None
 
         try:
@@ -170,7 +170,7 @@ class PyDroidIPCam:
             payload = 'on' if val else 'off'
         else:
             payload = val
-        return self._request('/settings/{}?set={}'.format(key, payload))
+        return self._request(f'/settings/{key}?set={payload}')
 
     def torch(self, activate=True):
         """Enable/disable the torch.
@@ -195,7 +195,7 @@ class PyDroidIPCam:
         """
         path = '/startvideo?force=1' if record else '/stopvideo?force=1'
         if record and tag is not None:
-            path = '/startvideo?force=1&tag={}'.format(URL(tag).raw_path)
+            path = f'/startvideo?force=1&tag={URL(tag).raw_path}'
 
         return self._request(path)
 
@@ -255,7 +255,7 @@ class PyDroidIPCam:
 
         Return a coroutine.
         """
-        return self._request('/settings/ptz?zoom={}'.format(zoom))
+        return self._request(f'/settings/ptz?zoom={zoom}')
 
     def set_scenemode(self, scenemode='auto'):
         """Set the video scene mode.

--- a/pydroid_ipcam.py
+++ b/pydroid_ipcam.py
@@ -11,26 +11,23 @@ ALLOWED_ORIENTATIONS = [
     'landscape', 'upsidedown', 'portrait', 'upsidedown_portrait'
 ]
 
-DEFAULT_PORT = 8080
-DEFAULT_SSL = True
-
 
 class PyDroidIPCam:
     """The Android device running IP Webcam."""
 
-    def __init__(self, loop, websession, host, port=DEFAULT_PORT, username=None,
-                 password=None, timeout=10, ssl=DEFAULT_SSL):
+    def __init__(self, loop, websession, host, port=8080, username=None,
+                 password=None, timeout=10, ssl=True):
         """Initialize the data oject."""
         self.loop = loop
         self.websession = websession
         self.status_data = None
         self.sensor_data = None
         self._host = host
-        self._port = port if port is not None else DEFAULT_PORT
+        self._port = port
         self._auth = None
         self._timeout = None
         self._available = True
-        self._ssl = ssl if ssl is not None else DEFAULT_SSL
+        self._ssl = ssl
 
         if username and password:
             self._auth = aiohttp.BasicAuth(username, password=password)


### PR DESCRIPTION
added ssl parameter
added default port

It is noteworthy that although the android app supports https, the certificate that is used is self signed, so when connecting one would have to disable certificate checks in python f.ex. like this:

```
async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
  [...]
```

fixes #7 